### PR TITLE
Fix Pillow - Variant need naming PIL

### DIFF
--- a/src/Pillow/Pillow.pas
+++ b/src/Pillow/Pillow.pas
@@ -25,7 +25,7 @@ type
     procedure Prepare(const AModel: TPyPackageModel); override;
     procedure ImportModule; override;
   public
-    property pillow: variant read AsVariant;
+    property PIL: variant read AsVariant;
   end;
 
 implementation
@@ -57,7 +57,7 @@ procedure TPillow.Prepare(const AModel: TPyPackageModel);
 begin
   inherited;
   with AModel do begin
-    PackageName := 'pillow';
+    PackageName := 'PIL';
     //NumPy from PIP
     PackageManagers.Add(
       TPyPackageManagerKind.pip,


### PR DESCRIPTION
Just tried out Pillow and RemBG (Basic sample in https://github.com/peardox/RemBGPillow)

Needed to change the name of the Variant to get it working - like OpenCV needs to be called cv2 Pillow needs to be called PIL for it to work

Once that's done it all works nicely

Check out the above Repo. The Image button will ask for a file (choose any image) then ask for a Save filename (make sure it ends in .png) and some magic removes the background saving the image.

Did this one Delphi-only so it's using variants to open, remove background and then save the result.
 